### PR TITLE
add default mysql config

### DIFF
--- a/cmd/upgrade/root.go
+++ b/cmd/upgrade/root.go
@@ -53,7 +53,12 @@ func newRootCmd(out io.Writer, args []string) (*cobra.Command, error) {
 			}
 
 			if config.MySql == nil {
-				klog.Fatalf("mysql is empty", err)
+				klog.Warningf("mysql is empty, use the default config")
+				config.MySql = &types.MySqlOptions{
+					Host:     "mysql.kubesphere-system.svc:3306",
+					Password: "password",
+					Username: "root",
+				}
 			}
 
 			// 1. dump legacy data


### PR DESCRIPTION
Signed-off-by: LiHui <andrewli@yunify.com>
ks-installer will delete msyql config from kubesphere-config after delete openpitrix-system. If the the node where openpitrix-jobs run crash, openpitrix-job will fail forever.