### PR TITLE
fix: import job app-store bucket Failed when it does not exist

### DIFF
--- a/cmd/import-app/import.go
+++ b/cmd/import-app/import.go
@@ -64,6 +64,7 @@ func newImportCmd() *cobra.Command {
 			fileList, err := file.Readdir(0)
 			if err != nil {
 				klog.Fatalf("read dir failed, error: %s", err)
+				os.Exit(0)
 			}
 
 			for _, fileInfo := range fileList {
@@ -88,6 +89,7 @@ func newImportCmd() *cobra.Command {
 				appVer, err := wf.CreateAppVer(context.TODO(), app, path.Join(chartDir, fileInfo.Name()))
 				if err != nil {
 					klog.Errorf("create app version failed, error: %s", err)
+
 				}
 				_ = appVer
 			}
@@ -233,6 +235,7 @@ func (wf *ImportWorkFlow) CreateApp(ctx context.Context, chrt *chart.Chart) (app
 			Name:        wf.importConfig.ReplaceAppName(chrt),
 			Description: chrt.Metadata.Description,
 			Icon:        chrt.Metadata.Icon,
+			AppHome:     chrt.Metadata.Home,
 		},
 	}
 

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -109,12 +109,12 @@ func NewS3Client(options *Options) (Interface, error) {
 	c.s3Client = s3.New(s)
 	c.s3Session = s
 	c.bucket = options.Bucket
-	object, err := c.s3Client.ListBuckets(&s3.ListBucketsInput{})
+	buckets, err := c.s3Client.ListBuckets(&s3.ListBucketsInput{})
 	if err != nil {
 		klog.Errorf("list bucket failed:%s", err)
 		return nil, err
 	}
-	for _, bucket := range object.Buckets {
+	for _, bucket := range buckets.Buckets {
 		if *bucket.Name == c.bucket {
 			return &c, nil
 		}


### PR DESCRIPTION
When execute import task, if the BUCKET do not exist, the task continues to the end,  in fact ,the import task failed.